### PR TITLE
Alteration so you can call the scripts from anywhere

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
  
-SLUG=$(basename $(dirname $PWD))
+BASEDIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+SLUG=$(basename $BASEDIR)
 
 # These are needed because this itself is a Git repo
-export GIT_WORK_TREE=$(dirname $PWD)/git
-export GIT_DIR=$(dirname $PWD)/git/.git
+export GIT_WORK_TREE=${BASEDIR}/git
+export GIT_DIR=${BASEDIR}/git/.git
 
 assets_exist=`git show-ref refs/heads/assets`
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,13 +4,14 @@
 MSG=${1-'Deploy from git'}
 BRANCH=${2-'trunk'}
 
-SLUG=$(basename $(dirname $PWD))
-SRC_DIR=$(dirname $PWD)/git
-DEST_DIR=$(dirname $PWD)/svn/$BRANCH
+BASEDIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+SLUG=$(basename $BASEDIR)
+SRC_DIR=${BASEDIR}/git
+DEST_DIR=${BASEDIR}/svn/$BRANCH
 
 # These are needed because this itself is a Git repo
-export GIT_WORK_TREE=$(dirname $PWD)/git
-export GIT_DIR=$(dirname $PWD)/git/.git
+export GIT_WORK_TREE=${BASEDIR}/git
+export GIT_DIR=${BASEDIR}/git/.git
 
 # make sure we're deploying from the right dir
 if [ ! -d "$SRC_DIR/.git" ]; then
@@ -19,9 +20,9 @@ if [ ! -d "$SRC_DIR/.git" ]; then
 fi
 
 # make sure the SVN repo exists
-if [ ! -d "$(dirname $PWD)/svn" ]; then
-	echo "Coudn't find the SVN repo at $(dirname $PWD)/svn. Trying to create one..."
-	svn co http://plugins.svn.wordpress.org/$SLUG/ $(dirname $PWD)/svn
+if [ ! -d "${BASEDIR}/svn" ]; then
+	echo "Coudn't find the SVN repo at ${BASEDIR}/svn. Trying to create one..."
+	svn co http://plugins.svn.wordpress.org/$SLUG/ ${BASEDIR}/svn
 	exit
 fi
 

--- a/pot.sh
+++ b/pot.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 TYPE=${1-'wp-plugin'}
-SLUG=$(basename $(dirname $PWD))
+
+BASEDIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+SLUG=$(basename $BASEDIR)
 
 # These are needed because this itself is a Git repo
-export GIT_WORK_TREE=$(dirname $PWD)/git
-export GIT_DIR=$(dirname $PWD)/git/.git
+export GIT_WORK_TREE=${BASEDIR}/git
+export GIT_DIR=${BASEDIR}/git/.git
 
 git checkout -f master
 
-php $PWD/wp-develop/tools/i18n/makepot.php $TYPE $GIT_WORK_TREE $GIT_WORK_TREE/languages/$SLUG.pot
+php $BASEDIR/wp-deploy/wp-develop/tools/i18n/makepot.php $TYPE $GIT_WORK_TREE $GIT_WORK_TREE/languages/$SLUG.pot

--- a/tag.sh
+++ b/tag.sh
@@ -8,11 +8,12 @@ fi
 # args
 TAG_NAME=$1
 
-SLUG=$(basename $(dirname $PWD))
+BASEDIR=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+SLUG=$(basename $BASEDIR)
 
 # These are needed because this itself is a Git repo
-export GIT_WORK_TREE=$(dirname $PWD)/git
-export GIT_DIR=$(dirname $PWD)/git/.git
+export GIT_WORK_TREE=${BASEDIR}/git
+export GIT_DIR=${BASEDIR}/git/.git
 
 git checkout -f master
 git tag $TAG_NAME


### PR DESCRIPTION
First thing that i noticed when checking out your setup is that the scripts only seemed to work if they were called from the proper location. This pull request should make the location not important anymore.

Basically it first changes the current dir to the directory of the script itself, before determining a BASEDIR and the SLUG.

All references to dirname $PWD are replaces to BASEDIR to avoid having to figure out where we are every time.
