### PR TITLE
Ability to keep git changelog on separate file. Remove MD bold ** from readme.md

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -44,6 +44,10 @@ cd $DEST_DIR
 # Transform the readme
 if [ -f readme.md ]; then
 	mv readme.md readme.txt
+	if [ -f CHANGELOG.md ]; then
+		cat CHANGELOG.md >> readme.txt
+		rm CHANGELOG.md
+	fi
 	sed -i '' -e 's/^# \(.*\)$/=== \1 ===/' -e 's/ #* ===$/ ===/' -e 's/^## \(.*\)$/== \1 ==/' -e 's/ #* ==$/ ==/' -e 's/^### \(.*\)$/= \1 =/' -e 's/ #* =$/ =/' readme.txt
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ if [ -f readme.md ]; then
 		cat CHANGELOG.md >> readme.txt
 		rm CHANGELOG.md
 	fi
-	sed -i '' -e 's/^# \(.*\)$/=== \1 ===/' -e 's/ #* ===$/ ===/' -e 's/^## \(.*\)$/== \1 ==/' -e 's/ #* ==$/ ==/' -e 's/^### \(.*\)$/= \1 =/' -e 's/ #* =$/ =/' readme.txt
+	sed -i '' -e 's/^# \(.*\)$/=== \1 ===/' -e 's/ #* ===$/ ===/' -e 's/^## \(.*\)$/== \1 ==/' -e 's/ #* ==$/ ==/' -e 's/^### \(.*\)$/= \1 =/' -e 's/ #* =$/ =/' -e 's/\*\*//g' readme.txt
 fi
 
 # svn addremove


### PR DESCRIPTION
For plugins thatkeep the changelog seperate in CHANGELOG.md with there git repo.

Also on GitHub I have the metadata titles bold with MD **. This was breaking the ability for wordpress.org to parse my readme.txt file.

Example:

```
**Tags:**                 metaboxes, forms, fields, options, settings  
**Requires at least:**    4.0  
**Tested up to:**         4.5  
**Stable tag:**           0.0.8  
```
